### PR TITLE
ZADD NX 옵션 추가 및 스케쥴러 기능 구현

### DIFF
--- a/webflux/src/main/java/com/example/webflux/WebfluxApplication.java
+++ b/webflux/src/main/java/com/example/webflux/WebfluxApplication.java
@@ -2,7 +2,9 @@ package com.example.webflux;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class WebfluxApplication {
 

--- a/webflux/src/main/java/com/example/webflux/config/CorsWebFilterConfig.java
+++ b/webflux/src/main/java/com/example/webflux/config/CorsWebFilterConfig.java
@@ -1,0 +1,30 @@
+package com.example.webflux.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+public class CorsWebFilterConfig {
+
+    @Bean
+    CorsWebFilter corsWebFilter() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOrigins(Collections.singletonList("http://localhost:8080"));
+        corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        corsConfiguration.setAllowedHeaders(Collections.singletonList("*"));
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return new CorsWebFilter(source);
+    }
+
+}

--- a/webflux/src/main/java/com/example/webflux/repository/RedisRepository.java
+++ b/webflux/src/main/java/com/example/webflux/repository/RedisRepository.java
@@ -10,4 +10,6 @@ public interface RedisRepository {
     Mono<Long> zRank(String queue, Long userId);
 
     Flux<ZSetOperations.TypedTuple<String>> popMin(String queue, Long count);
+
+    Flux<String> scan(String queue, Long count);
 }

--- a/webflux/src/main/java/com/example/webflux/repository/RedisRepository.java
+++ b/webflux/src/main/java/com/example/webflux/repository/RedisRepository.java
@@ -5,7 +5,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface RedisRepository {
-    Mono<Boolean> addZSet(String queue, Long userId, Long timestamp);
+    Mono<Boolean> addZSetIfAbsent(String queue, Long userId, Long timestamp);
 
     Mono<Long> zRank(String queue, Long userId);
 

--- a/webflux/src/main/java/com/example/webflux/repository/RedisRepositoryImpl.java
+++ b/webflux/src/main/java/com/example/webflux/repository/RedisRepositoryImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.connection.ReactiveZSetCommands;
 import org.springframework.data.redis.connection.zset.Tuple;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
@@ -37,5 +38,13 @@ public class RedisRepositoryImpl implements RedisRepository {
     @Override
     public Flux<ZSetOperations.TypedTuple<String>> popMin(String queue, Long count) {
         return reactiveRedisTemplate.opsForZSet().popMin(queue, count);
+    }
+
+    @Override
+    public Flux<String> scan(String pattern, Long count) {
+         return reactiveRedisTemplate.scan(ScanOptions.scanOptions()
+                 .match(pattern)
+                 .count(count)
+                 .build());
     }
 }

--- a/webflux/src/main/resources/application.yml
+++ b/webflux/src/main/resources/application.yml
@@ -11,3 +11,6 @@ spring:
 server:
   port: 9090
 
+scheduler:
+  enabled: true
+  max-allow-user-count: 3

--- a/webflux/src/test/java/com/example/webflux/controller/QueueControllerTest.java
+++ b/webflux/src/test/java/com/example/webflux/controller/QueueControllerTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
 @WebFluxTest(QueueController.class)
-class QueueQueueControllerTest {
+class QueueControllerTest {
 
     @Autowired
     private WebTestClient webTestClient;

--- a/webflux/src/test/java/com/example/webflux/repository/RedisRepositoryTest.java
+++ b/webflux/src/test/java/com/example/webflux/repository/RedisRepositoryTest.java
@@ -3,12 +3,16 @@ package com.example.webflux.repository;
 import com.example.webflux.EmbeddedRedis;
 import com.example.webflux.service.QueueManager;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAmount;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.test.context.ActiveProfiles;
@@ -40,22 +44,22 @@ public class RedisRepositoryTest {
         long timestamp = Instant.now().getEpochSecond();
         String queue = QueueManager.WAITING_QUEUE.getKey();
 
-        StepVerifier.create(redisRepository.addZSet(queue, userId, timestamp))
+        StepVerifier.create(redisRepository.addZSetIfAbsent(queue, userId, timestamp))
                 .expectNext(true)
                 .verifyComplete();
     }
 
+    // 같은 nx 옵션 없이 같은 key, value로 넣을 경우 score가 갱신되는 이슈가 있었다.
     @Test
     void addZSetWhenDuplicated() {
         Long userId = 1L;
-        long timestamp = Instant.now().getEpochSecond();
         String queue = QueueManager.WAITING_QUEUE.getKey();
 
-        StepVerifier.create(redisRepository.addZSet(queue, userId, timestamp))
+        StepVerifier.create(redisRepository.addZSetIfAbsent(queue, userId, Instant.now().getEpochSecond()))
                 .expectNext(true)
                 .verifyComplete();
 
-        StepVerifier.create(redisRepository.addZSet(queue, userId, timestamp))
+        StepVerifier.create(redisRepository.addZSetIfAbsent(queue, userId, Instant.now().getEpochSecond()))
                 .expectNext(false)
                 .verifyComplete();
     }
@@ -65,7 +69,7 @@ public class RedisRepositoryTest {
     void zRank() {
         String queue = QueueManager.WAITING_QUEUE.getKey();
 
-        StepVerifier.create(redisRepository.addZSet(queue,1L, 100L)
+        StepVerifier.create(redisRepository.addZSetIfAbsent(queue,1L, 100L)
                 .then(redisRepository.zRank(queue,1L)))
                 .expectNext(0L)
                 .verifyComplete();
@@ -75,8 +79,8 @@ public class RedisRepositoryTest {
     void zRankByMultiUser() {
         String queue = QueueManager.WAITING_QUEUE.getKey();
 
-        StepVerifier.create(redisRepository.addZSet( queue,1L, 100L)
-                .then(redisRepository.addZSet(queue,2L, 99L))
+        StepVerifier.create(redisRepository.addZSetIfAbsent( queue,1L, 100L)
+                .then(redisRepository.addZSetIfAbsent(queue,2L, 99L))
                 .then(redisRepository.zRank( queue,2L)))
                 .expectNext(0L)
                 .verifyComplete();
@@ -95,9 +99,9 @@ public class RedisRepositoryTest {
     void popMin() {
         String queue = QueueManager.WAITING_QUEUE.getKey();
 
-        Mono<Boolean> setup = redisRepository.addZSet(queue, 1L, 100L)
-                .then(redisRepository.addZSet(queue, 2L, 101L))
-                .then(redisRepository.addZSet(queue, 3L, 103L));
+        Mono<Boolean> setup = redisRepository.addZSetIfAbsent(queue, 1L, 100L)
+                .then(redisRepository.addZSetIfAbsent(queue, 2L, 101L))
+                .then(redisRepository.addZSetIfAbsent(queue, 3L, 103L));
 
         Flux<ZSetOperations.TypedTuple<String>> result = setup.thenMany(redisRepository.popMin(queue, 4L)); // Mono -> Flux
 

--- a/webflux/src/test/resources/application-test.yml
+++ b/webflux/src/test/resources/application-test.yml
@@ -6,3 +6,6 @@ spring:
     redis:
       host: localhost
       port: 63790
+scheduler:
+  enabled: false
+  max-allow-user-count: 10

--- a/website/src/main/resources/templates/waiting-room.html
+++ b/website/src/main/resources/templates/waiting-room.html
@@ -48,14 +48,33 @@
         잠시만 기다려 주시기 바랍니다.
     </div>
 
-    <div class="rank" th:text="${rank} + ' 명'">0 명</div>
-
-    <div class="time" th:text="'예상 대기 시간: 약 ' + ${rank} + ' 분'">예상 대기 시간: 약 0분</div>
+    <div class="rank"><span id="rank">[[${rank}]]</span> 명</div>
 
     <div style="margin-top: 2rem;">
-        순서가 되면 자동으로 접속됩니다.<br/>
-        페이지 새로고침시 처음부터 대기하셔야 합니다.
+        순서가 되면 자동으로 접속됩니다.
     </div>
 </div>
+<script>
+    function fetchWaitingQueue() {
+        const userId = `[[${userId}]]`;
+        const queryParam = new URLSearchParams({userId : userId});
+        const _rank = document.querySelector("#rank");
+
+        fetch('http://localhost:9090/api/v1/queue/checked?' + queryParam, { credentials : "include" })
+            .then(response => response.json())
+            .then(data => {
+                const rank = parseInt(data.rank);
+                if(rank < 1) {
+                    _rank.innerHTML = '0';
+                    window.location.href = `/index?${queryParam}`;
+                    return;
+                }
+
+                _rank.innerHTML = `${rank}`;
+            }).catch(error => console.error(error));
+    }
+
+    setInterval(fetchWaitingQueue, 3000);
+</script>
 </body>
 </html>


### PR DESCRIPTION
- 대기열 페이지에서 새로고침시 순위 밀림 현상 발생💩
  - 원인: 템플릿 메서드 add(..) 호출할 경우 같은 key, value 인 경우 score 갱신되고 결과값을 0을 반환
  - 해결: `NX` 옵션을 추가하여 중복 elements 방지 ✨
- 스프링 스케쥴러 활용해 대기열 처리 기능 구현
- 대기열 페이지에서 **HTTP Polling** 방식으로 순위 조회 후 갱신하도록 스크립트 구현